### PR TITLE
test: verify splash screen navigation

### DIFF
--- a/src/app/splash-screen/splash-screen.component.spec.ts
+++ b/src/app/splash-screen/splash-screen.component.spec.ts
@@ -1,17 +1,22 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { Router } from '@angular/router';
 
 import { SplashScreenComponent } from './splash-screen.component';
 
 describe('SplashScreenComponent', () => {
   let component: SplashScreenComponent;
   let fixture: ComponentFixture<SplashScreenComponent>;
+  let router: Router;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SplashScreenComponent]
-    })
-    .compileComponents();
+      imports: [SplashScreenComponent],
+      providers: [
+        { provide: Router, useValue: jasmine.createSpyObj('Router', ['navigate']) }
+      ]
+    }).compileComponents();
 
+    router = TestBed.inject(Router);
     fixture = TestBed.createComponent(SplashScreenComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -20,4 +25,12 @@ describe('SplashScreenComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should navigate to homepage after timeout', fakeAsync(() => {
+    const navigateSpy = router.navigate as jasmine.Spy;
+    tick(2999);
+    expect(navigateSpy).not.toHaveBeenCalled();
+    tick(1);
+    expect(navigateSpy).toHaveBeenCalledWith(['/homepage']);
+  }));
 });


### PR DESCRIPTION
## Summary
- add Router spy to splash screen test
- test navigation timing with fakeAsync and tick

## Testing
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_6842c629d510832cafd1e011dede1ed5