### PR TITLE
fix: correct lifecycle hook name

### DIFF
--- a/src/dataapi.service.ts
+++ b/src/dataapi.service.ts
@@ -12,7 +12,7 @@ export class DataapiService {
     this.setBaseUrl(); // Initialize baseurl based on hostname
   }
 
-  ngOninit(): any {
+  ngOnInit(): any {
     console.log(window.location.hostname)
     this.baseurl = "http://localhost:9999";
     this.setBaseUrl();


### PR DESCRIPTION
## Summary
- correct the `ngOnInit` method name in `DataapiService`

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6842c60f8e58832c9d2e26553cda8020